### PR TITLE
Initialize UIAlertAction when invoked

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Pod/Classes/LKAlertController.swift
+++ b/Pod/Classes/LKAlertController.swift
@@ -57,9 +57,11 @@ public class LKAlertController {
     :param: handler  Closure to call when the button is pressed
     */
     public func addAction(title: String, style: UIAlertActionStyle, handler: ((UIAlertAction!) -> Void)? = nil) -> LKAlertController {
-        var action = UIAlertAction(title: title, style: style, handler: { _ in })
+        var action: UIAlertAction
         if let handler = handler {
             action = UIAlertAction(title: title, style: style, handler: handler)
+        } else {
+            action = UIAlertAction(title: title, style: style, handler: { _ in })
         }
         
         alertController.addAction(action)


### PR DESCRIPTION
This initializes the UIAlertAction once based on the result of the optional chaining and removes the resetting of the action variable twice when there is a handler.
