### PR TITLE
iPad Crash and presentationController Support

### DIFF
--- a/LKAlertController.podspec
+++ b/LKAlertController.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "LKAlertController"
-  s.version          = "1.2.3"
+  s.version          = "1.3.0"
   s.summary          = "An easy to use UIAlertController builder for swift"
   s.homepage         = "https://github.com/lightningkite/LKAlertController"
   s.license          = 'MIT'

--- a/Pod/Classes/LKAlertController.swift
+++ b/Pod/Classes/LKAlertController.swift
@@ -39,6 +39,9 @@ public class LKAlertController {
             alertController.message = newValue
         }
     }
+
+    /** Used internally to determine if the user has set the popover controller source for presenting */
+    internal var configuredPopoverController = false
     
     /**
     Initialize a new LKAlertController
@@ -100,12 +103,25 @@ public class LKAlertController {
         //Present the alert
         else if let viewController = UIApplication.sharedApplication().keyWindow?.rootViewController {
             //Find the presented view controller
-            var topController = viewController
-            while (topController.presentedViewController != nil) {
-                topController = topController.presentedViewController!
+            var presentedController = viewController
+            while (presentedController.presentedViewController != nil) {
+                presentedController = presentedController.presentedViewController!
             }
             
-            topController.presentViewController(alertController, animated: animated, completion: completion)
+            //If the user has not configured the popover controller source on ipad then set it to the presenting view
+            if self is ActionSheet && !configuredPopoverController,
+                let popoverController = alertController.popoverPresentationController {
+                    
+                    var topController = presentedController
+                    while (topController.childViewControllers.last != nil) {
+                        topController = topController.childViewControllers.last as! UIViewController
+                    }
+                    
+                    popoverController.sourceView = topController.view
+                    popoverController.sourceRect = topController.view.bounds
+            }
+            
+            presentedController.presentViewController(alertController, animated: animated, completion: completion)
         }
     }
     
@@ -261,5 +277,36 @@ public class ActionSheet: LKAlertController {
     */
     public override func addAction(title: String, style: UIAlertActionStyle, handler: ((UIAlertAction!) -> Void)?) -> ActionSheet {
         return super.addAction(title, style: style, handler: handler) as! ActionSheet
+    }
+    
+    /**
+    Set the presenting bar button item. Used for presenting the action sheet on iPad.
+    If this isn't set, it will default to the presenting view on iPad.
+    
+    :param: item  UIBarButtonItem that the action sheet will present from
+    */
+    public func setBarButtonItem(item: UIBarButtonItem) -> ActionSheet {
+        if let popoverController = alertController.popoverPresentationController {
+            popoverController.barButtonItem = item
+        }
+        super.configuredPopoverController = true
+        
+        return self
+    }
+    
+    /**
+    Set the presenting source view. Used for presenting the action sheet on iPad.
+    If this isn't set, it will default to the presenting view on iPad.
+    
+    :param: source  The view the action sheet will present from
+    */
+    public func setPresentingSource(source: UIView) -> ActionSheet {
+        if let popoverController = alertController.popoverPresentationController {
+            popoverController.sourceView = source
+            popoverController.sourceRect = source.bounds
+        }
+        super.configuredPopoverController = true
+        
+        return self
     }
 }


### PR DESCRIPTION
Add ability to set the presentationController's BarButtonItem or source view for iPad support on ActionSheets

Fixes #12 
