### PR TITLE
Updated to Swift 3 (verify modification)

### DIFF
--- a/Example/LKAlertController.xcodeproj/project.pbxproj
+++ b/Example/LKAlertController.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 				TargetAttributes = {
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -323,6 +324,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -338,6 +340,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -286,6 +286,11 @@
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0640;
+				TargetAttributes = {
+					5CA33C1FF2D5E9409EA7E2DB = {
+						LastSwiftMigration = 0800;
+					};
+				};
 			};
 			buildConfigurationList = E28A3E191A9B675691ADAA6F /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -430,6 +435,7 @@
 				PRODUCT_NAME = LKAlertController;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -458,6 +464,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Example/Tests/LKAlertControllerTests.swift
+++ b/Example/Tests/LKAlertControllerTests.swift
@@ -14,13 +14,13 @@ import LKAlertController
 class LKAlertControllerTests: XCTestCase {
     
     func testCreateAlertControllerAlert() {
-        let controller = LKAlertController(style: .Alert).getAlertController()
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.Alert, "The style was not initialized correctly")
+        let controller = LKAlertController(style: .alert).getAlertController()
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.alert, "The style was not initialized correctly")
     }
     
     func testCreateAlertControllerActionSheet() {
-        let controller = LKAlertController(style: .ActionSheet).getAlertController()
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.ActionSheet, "The style was not initialized correctly")
+        let controller = LKAlertController(style: .actionSheet).getAlertController()
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.actionSheet, "The style was not initialized correctly")
     }
     
     func testAddAction() {
@@ -28,12 +28,12 @@ class LKAlertControllerTests: XCTestCase {
             print("TESTING")
         }
         
-        let controller = LKAlertController(style: .Alert).addAction("Okay", style: .Default, handler: handler).getAlertController()
+        let controller = LKAlertController(style: .alert).addAction("Okay", style: .default, handler: handler).getAlertController()
         XCTAssertEqual(controller.actions.count, 1, "The number of actions was incorrect")
         
         if let action = controller.actions.first {
             XCTAssertEqual(action.title, "Okay", "The title of the action was incorrect")
-            XCTAssertEqual(action.style, UIAlertActionStyle.Default, "The style was incorrect")
+            XCTAssertEqual(action.style, UIAlertActionStyle.default, "The style was incorrect")
         }
         else {
             XCTFail("Could not load the action")
@@ -45,15 +45,15 @@ class LKAlertControllerTests: XCTestCase {
             print("TESTING")
         }
         
-        let controller = LKAlertController(style: .Alert)
-            .addAction("Okay", style: .Default, handler: handler).addAction("Cancel", style: .Cancel, handler: handler)
+        let controller = LKAlertController(style: .alert)
+            .addAction("Okay", style: .default, handler: handler).addAction("Cancel", style: .cancel, handler: handler)
             .getAlertController()
         
         XCTAssertEqual(controller.actions.count, 2, "The number of actions was incorrect")
         
         if let action = controller.actions.first {
             XCTAssertEqual(action.title, "Okay", "The title of the action was incorrect")
-            XCTAssertEqual(action.style, UIAlertActionStyle.Default, "The style was incorrect")
+            XCTAssertEqual(action.style, UIAlertActionStyle.default, "The style was incorrect")
         }
         else {
             XCTFail("Could not load the first action")
@@ -61,7 +61,7 @@ class LKAlertControllerTests: XCTestCase {
         
         if let action = controller.actions.last {
             XCTAssertEqual(action.title, "Cancel", "The title of the action was incorrect")
-            XCTAssertEqual(action.style, UIAlertActionStyle.Cancel, "The style was incorrect")
+            XCTAssertEqual(action.style, UIAlertActionStyle.cancel, "The style was incorrect")
         }
         else {
             XCTFail("Could not load the last action")
@@ -69,9 +69,9 @@ class LKAlertControllerTests: XCTestCase {
     }
     
     func testOverrideShowForTesting() {
-        let expectation = expectationWithDescription("Show override")
+        let expectation = self.expectation(description: "Show override")
         
-        let theStyle = UIAlertControllerStyle.Alert
+        let theStyle = UIAlertControllerStyle.alert
         let theTitle = "Alert Title"
         let theMessage = "Alert Message"
         
@@ -95,73 +95,73 @@ class LKAlertControllerTests: XCTestCase {
         
         Alert(title: theTitle, message: theMessage).show()
         
-        waitForExpectationsWithTimeout(0.5, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
     
     func testShow() {
-        let expectation = expectationWithDescription("Show override")
+        let expectation = self.expectation(description: "Show override")
         
         LKAlertController.overrideShowForTesting { (style, title, message, actions, fields) -> Void in
             XCTAssertEqual(actions.count, 0, "Incorrect number of buttons")
-            XCTAssertEqual(style, UIAlertControllerStyle.Alert, "Incorrect Style of the alert")
+            XCTAssertEqual(style, UIAlertControllerStyle.alert, "Incorrect Style of the alert")
             
             expectation.fulfill()
         }
         
-        LKAlertController(style: .Alert).show()
+        LKAlertController(style: .alert).show()
         
-        waitForExpectationsWithTimeout(0.5, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
     func testShowAnimated() {
-        let expectation = expectationWithDescription("Show override")
+        let expectation = self.expectation(description: "Show override")
         
         LKAlertController.overrideShowForTesting { (style, title, message, actions, fields) -> Void in
             XCTAssertEqual(actions.count, 0, "Incorrect number of buttons")
-            XCTAssertEqual(style, UIAlertControllerStyle.Alert, "Incorrect Style of the alert")
+            XCTAssertEqual(style, UIAlertControllerStyle.alert, "Incorrect Style of the alert")
             
             expectation.fulfill()
         }
         
-        LKAlertController(style: .Alert).show(animated: true)
+        LKAlertController(style: .alert).show(animated: true)
         
-        waitForExpectationsWithTimeout(0.5, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
     
     func testShowAnimatedCompletion() {
-        let expectation = expectationWithDescription("Show override")
+        let expectation = self.expectation(description: "Show override")
         
         LKAlertController.overrideShowForTesting { (style, title, message, actions, fields) -> Void in
             XCTAssertEqual(actions.count, 0, "Incorrect number of buttons")
-            XCTAssertEqual(style, UIAlertControllerStyle.Alert, "Incorrect Style of the alert")
+            XCTAssertEqual(style, UIAlertControllerStyle.alert, "Incorrect Style of the alert")
             
             expectation.fulfill()
         }
         
-        LKAlertController(style: .Alert).show(animated: true, completion: nil)
+        LKAlertController(style: .alert).show(animated: true, completion: nil)
         
-        waitForExpectationsWithTimeout(0.5, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
 	
 	func testDelay() {
-		let expectation = expectationWithDescription("Delay testing")
+		let expectation = self.expectation(description: "Delay testing")
 		
-		var startTime = NSDate()
+		var startTime = Date()
 		
 		LKAlertController.overrideShowForTesting { (style, title, message, actions, fields) -> Void in
 			
-			let endTime = NSDate()
-			let delayTime = Int(round(endTime.timeIntervalSinceDate(startTime)))
+			let endTime = Date()
+			let delayTime = Int(round(endTime.timeIntervalSince(startTime)))
 			
 			XCTAssertEqual(delayTime, 5)
 			
 			expectation.fulfill()
 		}
 		
-		startTime = NSDate()
+		startTime = Date()
 		
 		Alert(title: "Title", message: "Message").addAction("Cancel").delay(5).show()
 		
-		waitForExpectationsWithTimeout(6, handler: nil)
+		waitForExpectations(timeout: 6, handler: nil)
 	}
 }
 
@@ -171,7 +171,7 @@ class AlertTests: XCTestCase {
         let controller = Alert().getAlertController()
         XCTAssertNil(controller.title, "The title was not nil")
         XCTAssertNil(controller.message, "The message was not nil")
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.Alert, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.alert, "The controller type was incorrect")
     }
     
     func testInitWithTitle() {
@@ -181,14 +181,14 @@ class AlertTests: XCTestCase {
             XCTAssertEqual(title, "the title", "The title was incorrect")
         }
         XCTAssertNil(controller.message, "The message was not nil")
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.Alert, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.alert, "The controller type was incorrect")
     }
     
     func testInitWithNilTitle() {
         let controller = Alert(title: nil).getAlertController()
         XCTAssertNil(controller.title, "The title was not nil")
         XCTAssertNil(controller.message, "The message was not nil")
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.Alert, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.alert, "The controller type was incorrect")
     }
     
     func testInitWithMessage() {
@@ -201,14 +201,14 @@ class AlertTests: XCTestCase {
         if controller.title != nil {
             XCTAssertEqual(controller.title!, "", "The title was not blank")
         }
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.Alert, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.alert, "The controller type was incorrect")
     }
     
     func testInitWithNilMessage() {
         let controller = Alert(message: nil).getAlertController()
         XCTAssertNil(controller.message, "The message was not nil")
         XCTAssertNil(controller.title, "The title was not nil")
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.Alert, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.alert, "The controller type was incorrect")
     }
     
     func testInitWithTitleAndMessage() {
@@ -221,7 +221,7 @@ class AlertTests: XCTestCase {
         if let message = controller.message {
             XCTAssertEqual(message, "the message", "The message was incorrect")
         }
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.Alert, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.alert, "The controller type was incorrect")
     }
     
     func testInitWithNilTitleAndMessage() {
@@ -231,7 +231,7 @@ class AlertTests: XCTestCase {
         if let message = controller.message {
             XCTAssertEqual(message, "the message", "The message was incorrect")
         }
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.Alert, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.alert, "The controller type was incorrect")
     }
     
     func testInitWithTitleAndNilMessage() {
@@ -241,22 +241,22 @@ class AlertTests: XCTestCase {
             XCTAssertEqual(controller.title!, "the title", "The title was incorrect")
         }
         XCTAssertNil(controller.message, "The message was not nil")
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.Alert, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.alert, "The controller type was incorrect")
     }
     
     func testInitWithNilTitleAndNilMessage() {
         let controller = Alert(title: nil, message: nil).getAlertController()
         XCTAssertNil(controller.title, "The title was not nil")
         XCTAssertNil(controller.message, "The message was not nil")
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.Alert, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.alert, "The controller type was incorrect")
     }
     
     func testShow() {
-        let expectation = expectationWithDescription("Show override")
+        let expectation = self.expectation(description: "Show override")
         
         LKAlertController.overrideShowForTesting { (style, title, message, actions, fields) -> Void in
             XCTAssertEqual(actions.count, 1, "Incorrect number of buttons")
-            XCTAssertEqual(style, UIAlertControllerStyle.Alert, "Incorrect Style of the alert")
+            XCTAssertEqual(style, UIAlertControllerStyle.alert, "Incorrect Style of the alert")
             
             if let button = actions.first as? UIAlertAction {
                 XCTAssertEqual(button.title, "Cancel", "Incorrect title of button")
@@ -270,18 +270,18 @@ class AlertTests: XCTestCase {
         
         Alert(title: "Title", message: "Message").addAction("Cancel").show()
         
-        waitForExpectationsWithTimeout(0.5, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
     
     func testShowOkay() {
-        let expectation = expectationWithDescription("Show override")
+        let expectation = self.expectation(description: "Show override")
         
         LKAlertController.overrideShowForTesting { (style, title, message, actions, fields) -> Void in
             XCTAssertEqual(actions.count, 1, "Incorrect number of buttons")
             
             if let button = actions.first as? UIAlertAction {
                 XCTAssertEqual(button.title, "Okay", "Incorrect title of button")
-                XCTAssertEqual(button.style, UIAlertActionStyle.Cancel, "Incorrect style of button")
+                XCTAssertEqual(button.style, UIAlertActionStyle.cancel, "Incorrect style of button")
             }
             else {
                 XCTFail("No button")
@@ -292,11 +292,11 @@ class AlertTests: XCTestCase {
         
         Alert(title: "Title", message: "Message").showOkay()
         
-        waitForExpectationsWithTimeout(0.5, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
     
     func testAddTextField() {
-        let expectation = expectationWithDescription("Show override")
+        let expectation = self.expectation(description: "Show override")
         
         LKAlertController.overrideShowForTesting { (style, title, message, actions, fields) -> Void in
             XCTAssertNotNil(fields, "Fields was nil")
@@ -304,7 +304,7 @@ class AlertTests: XCTestCase {
                 XCTAssertEqual(fields!.count, 1, "Incorrect number of fields")
             }
             
-            if let field = fields?.first as? UITextField, placeholder = field.placeholder {
+            if let field = fields?.first as? UITextField, let placeholder = field.placeholder {
                 XCTAssertEqual(placeholder, "the placeholder", "incorrect placeholder")
             }
             else {
@@ -317,13 +317,13 @@ class AlertTests: XCTestCase {
         var textField = UITextField()
         textField.placeholder = "the placeholder"
         
-        Alert(message: "text field alert").addTextField(&textField).showOkay()
+        Alert(message: "text field alert").addTextField(textField).showOkay()
         
-        waitForExpectationsWithTimeout(0.5, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
     
     func testAddMultipleField() {
-        let expectation = expectationWithDescription("Show override")
+        let expectation = self.expectation(description: "Show override")
         
         LKAlertController.overrideShowForTesting { (style, title, message, actions, fields) -> Void in
             XCTAssertNotNil(fields, "Fields was nil")
@@ -332,7 +332,7 @@ class AlertTests: XCTestCase {
             }
             
             if let first = fields?.first as? UITextField,
-                second = fields?.last as? UITextField {
+                let second = fields?.last as? UITextField {
                     
                     XCTAssertNotNil(first.placeholder, "placeholder nil")
                     if first.placeholder != nil {
@@ -344,7 +344,7 @@ class AlertTests: XCTestCase {
                     if second.placeholder != nil {
                         XCTAssertEqual(second.placeholder!, "password", "incorrect placeholder")
                     }
-                    XCTAssertTrue(second.secureTextEntry, "Secure text entry not enabled")
+                    XCTAssertTrue(second.isSecureTextEntry, "Secure text entry not enabled")
             }
             else {
                 XCTFail("No text field")
@@ -353,25 +353,25 @@ class AlertTests: XCTestCase {
             expectation.fulfill()
         }
         
-        var first = UITextField()
+        let first = UITextField()
         first.placeholder = "username"
         first.text = "user"
         
-        var second = UITextField()
+        let second = UITextField()
         second.placeholder = "password"
-        second.secureTextEntry = true
+        second.isSecureTextEntry = true
         
-        Alert(message: "text field alert").addTextField(&first).addTextField(&second).showOkay()
+        Alert(message: "text field alert").addTextField(first).addTextField(second).showOkay()
         
-        waitForExpectationsWithTimeout(0.5, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
     
     func testNevermindExtension() {
-        let expectation = expectationWithDescription("Nevermind Extension")
+        let expectation = self.expectation(description: "Nevermind Extension")
         
         LKAlertController.overrideShowForTesting { (style, title, message, actions, fields) -> Void in
             XCTAssertEqual(actions.count, 1, "Incorrect number of buttons")
-            XCTAssertEqual(style, UIAlertControllerStyle.Alert, "Incorrect Style of the alert")
+            XCTAssertEqual(style, UIAlertControllerStyle.alert, "Incorrect Style of the alert")
             
             if let button = actions.first as? UIAlertAction {
                 XCTAssertEqual(button.title, "Nevermind", "Incorrect title of button")
@@ -385,7 +385,7 @@ class AlertTests: XCTestCase {
         
         Alert().showNevermind()
         
-        waitForExpectationsWithTimeout(0.5, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
 }
 
@@ -395,7 +395,7 @@ class ActionSheetTests: XCTestCase {
         let controller = ActionSheet().getAlertController()
         XCTAssertNil(controller.title, "The title was not nil")
         XCTAssertNil(controller.message, "The message was not nil")
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.ActionSheet, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.actionSheet, "The controller type was incorrect")
     }
     
     func testInitWithTitle() {
@@ -405,7 +405,7 @@ class ActionSheetTests: XCTestCase {
             XCTAssertEqual(title, "the title", "The title was incorrect")
         }
         XCTAssertNil(controller.message, "The message was not nil")
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.ActionSheet, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.actionSheet, "The controller type was incorrect")
     }
     
     func testInitWithNilTitle() {
@@ -424,14 +424,14 @@ class ActionSheetTests: XCTestCase {
         if controller.title != nil {
             XCTAssertEqual(controller.title!, "", "The title was not blank")
         }
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.ActionSheet, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.actionSheet, "The controller type was incorrect")
     }
     
     func testInitWithNilMessage() {
         let controller = ActionSheet(message: nil).getAlertController()
         XCTAssertNil(controller.message, "The message was not nil")
         XCTAssertNil(controller.title, "The title was not nil")
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.ActionSheet, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.actionSheet, "The controller type was incorrect")
     }
     
     func testInitWithTitleAndMessage() {
@@ -444,7 +444,7 @@ class ActionSheetTests: XCTestCase {
         if let message = controller.message {
             XCTAssertEqual(message, "the message", "The message was incorrect")
         }
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.ActionSheet, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.actionSheet, "The controller type was incorrect")
     }
     
     func testInitWithNilTitleAndMessage() {
@@ -454,7 +454,7 @@ class ActionSheetTests: XCTestCase {
         if let message = controller.message {
             XCTAssertEqual(message, "the message", "The message was incorrect")
         }
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.ActionSheet, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.actionSheet, "The controller type was incorrect")
     }
     
     func testInitWithTitleAndNilMessage() {
@@ -464,22 +464,22 @@ class ActionSheetTests: XCTestCase {
             XCTAssertEqual(controller.title!, "the title", "The title was incorrect")
         }
         XCTAssertNil(controller.message, "The message was not nil")
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.ActionSheet, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.actionSheet, "The controller type was incorrect")
     }
     
     func testInitWithNilTitleAndNilMessage() {
         let controller = ActionSheet(title: nil, message: nil).getAlertController()
         XCTAssertNil(controller.title, "The title was not nil")
         XCTAssertNil(controller.message, "The message was not nil")
-        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.ActionSheet, "The controller type was incorrect")
+        XCTAssertEqual(controller.preferredStyle, UIAlertControllerStyle.actionSheet, "The controller type was incorrect")
     }
     
     func testShow() {
-        let expectation = expectationWithDescription("Show override")
+        let expectation = self.expectation(description: "Show override")
         
         LKAlertController.overrideShowForTesting { (style, title, message, actions, fields) -> Void in
             XCTAssertEqual(actions.count, 1, "Incorrect number of buttons")
-            XCTAssertEqual(style, UIAlertControllerStyle.ActionSheet, "Incorrect Style of the alert")
+            XCTAssertEqual(style, UIAlertControllerStyle.actionSheet, "Incorrect Style of the alert")
             
             if let button = actions.first as? UIAlertAction {
                 XCTAssertEqual(button.title, "Cancel", "Incorrect title of button")
@@ -493,12 +493,12 @@ class ActionSheetTests: XCTestCase {
         
         ActionSheet(title: "Title", message: "Message").addAction("Cancel").show()
         
-        waitForExpectationsWithTimeout(0.5, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
     }
     
     func testGithubIssue26() {
         //https://github.com/lightningkite/LKALertController/issues/26
-        ActionSheet().addAction("Test", style: .Default, handler: { _ in print("Test") }).show()
+        ActionSheet().addAction("Test", style: .default, handler: { _ in print("Test") }).show()
     }
 }
 
@@ -506,7 +506,7 @@ class ActionSheetTests: XCTestCase {
 extension Alert {
 	///Shortcut method for adding a nevermind button and showing the alert
 	public func showNevermind() {
-		addAction("Nevermind", style: .Cancel, preferredAction: false, handler: nil)
+		addAction("Nevermind", style: .cancel, preferredAction: false, handler: nil)
 		show()
 	}
 }

--- a/Pod/Classes/LKAlertController.swift
+++ b/Pod/Classes/LKAlertController.swift
@@ -15,7 +15,7 @@ Use Alert or ActionSheet instead
 */
 public class LKAlertController {
 	///UIAlertActions callback
-    public typealias actionHandler = UIAlertAction! -> Void
+    public typealias actionHandler = (UIAlertAction!) -> Void
     
     ///Internal alert controller to present to the user
     internal var alertController: UIAlertController
@@ -24,10 +24,10 @@ public class LKAlertController {
 	internal var presentationSource: UIViewController? = nil
 	
 	///Internal storage of time to delay before presenting
-	internal var delayTime: NSTimeInterval? = nil
+	internal var delayTime: TimeInterval? = nil
 	
     ///Internal static variable to store the override the show method for testing purposes
-    internal static var alertTester: ((style: UIAlertControllerStyle, title: String?, message: String?, actions: [AnyObject], fields: [AnyObject]?) -> Void)? = nil
+    internal static var alertTester: ((_ style: UIAlertControllerStyle, _ title: String?, _ message: String?, _ actions: [AnyObject], _ fields: [AnyObject]?) -> Void)? = nil
     
     ///Title of the alert controller
     internal var title: String? {
@@ -69,7 +69,7 @@ public class LKAlertController {
      - parameter style:  Style of the button (.Default, .Cancel, .Destructive)
      - parameter handler:  Closure to call when the button is pressed
      */
-    public func addAction(title: String, style: UIAlertActionStyle, handler: actionHandler? = nil) -> LKAlertController {
+    public func addAction(_ title: String, style: UIAlertActionStyle, handler: actionHandler? = nil) -> LKAlertController {
         addAction(title, style: style, preferredAction: false, handler: handler)
         
         return self
@@ -84,7 +84,7 @@ public class LKAlertController {
     - parameter preferredAction: Whether or not this action is the default action when return is pressed on a hardware keyboard
     - parameter handler:  Closure to call when the button is pressed
     */
-    internal func addAction(title: String, style: UIAlertActionStyle, preferredAction: Bool = false, handler: actionHandler? = nil) -> LKAlertController {
+    internal func addAction(_ title: String, style: UIAlertActionStyle, preferredAction: Bool = false, handler: actionHandler? = nil) -> LKAlertController {
         var action: UIAlertAction
         if let handler = handler {
             action = UIAlertAction(title: title, style: style, handler: handler)
@@ -104,13 +104,13 @@ public class LKAlertController {
     }
 	
 	///Set the view controller to present the alert in. By default this is the top controller in the window.
-	public func presentIn(source: UIViewController) -> LKAlertController {
+	public func presentIn(_ source: UIViewController) -> LKAlertController {
 		presentationSource = source
 		return self
 	}
 	
 	//Delay the presentation of the controller.
-	public func delay(time: NSTimeInterval) -> LKAlertController {
+	public func delay(_ time: TimeInterval) -> LKAlertController {
 		delayTime = time
 		return self
 	}
@@ -125,7 +125,7 @@ public class LKAlertController {
     
     - parameter animated:  Whether to animate into the view or not
     */
-    public func show(animated animated: Bool) {
+    public func show(animated: Bool) {
         show(animated: animated, completion: nil)
     }
     
@@ -135,11 +135,11 @@ public class LKAlertController {
     - parameter animated:  Whether to animate into the view or not
     - parameter completion:  Closure to call when the button is pressed
     */
-    public func show(animated animated: Bool, completion: (() -> Void)?) {
+    public func show(animated: Bool, completion: (() -> Void)?) {
 		//If a delay time has been set, delay the presentation of the alert by the delayTime
 		if let time = delayTime {
-			let dispatchTime = dispatch_time(DISPATCH_TIME_NOW, Int64(time * Double(NSEC_PER_SEC)))
-			dispatch_after(dispatchTime, dispatch_get_main_queue()) {
+			let dispatchTime = DispatchTime.now() + Double(Int64(time * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
+			DispatchQueue.main.asyncAfter(deadline: dispatchTime) {
 				self.show(animated: animated, completion: completion)
 			}
 			
@@ -149,14 +149,14 @@ public class LKAlertController {
 		
         //Override for testing
         if let alertTester = LKAlertController.alertTester {
-            alertTester(style: alertController.preferredStyle, title: title, message: message, actions: alertController.actions, fields: alertController.textFields)
+            alertTester(alertController.preferredStyle, title, message, alertController.actions, alertController.textFields)
             LKAlertController.alertTester = nil
         }
         //Present the alert
-        else if let viewController = UIApplication.sharedApplication().keyWindow?.rootViewController {
+        else if let viewController = UIApplication.shared.keyWindow?.rootViewController {
             //Find the presented view controller
             var presentedController = viewController
-            while presentedController.presentedViewController != nil && presentedController.presentedViewController?.isBeingDismissed() == false {
+            while presentedController.presentedViewController != nil && presentedController.presentedViewController?.isBeingDismissed == false {
                 presentedController = presentedController.presentedViewController!
             }
             
@@ -178,8 +178,8 @@ public class LKAlertController {
 				presentedController = source
 			}
 			
-			dispatch_async(dispatch_get_main_queue()) {
-				presentedController.presentViewController(self.alertController, animated: animated, completion: completion)
+			DispatchQueue.main.async {
+				presentedController.present(self.alertController, animated: animated, completion: completion)
 			}
         }
     }
@@ -190,7 +190,7 @@ public class LKAlertController {
     }
     
     ///Override the show function with a closure for using with your unit tests
-    public class func overrideShowForTesting(callback: ((style: UIAlertControllerStyle, title: String?, message: String?, actions: [AnyObject], fields: [AnyObject]?) -> Void)?) {
+    public class func overrideShowForTesting(_ callback: ((_ style: UIAlertControllerStyle, _ title: String?, _ message: String?, _ actions: [AnyObject], _ fields: [AnyObject]?) -> Void)?) {
         alertTester = callback
     }
 }
@@ -200,7 +200,7 @@ public class LKAlertController {
 public class Alert: LKAlertController {
     ///Create a new alert without a title or message
     public init() {
-        super.init(style: .Alert)
+        super.init(style: .alert)
     }
     
     /**
@@ -209,7 +209,7 @@ public class Alert: LKAlertController {
     - parameter title:  Title of the alert
     */
     public init(title: String?) {
-        super.init(style: .Alert)
+        super.init(style: .alert)
         self.title = title
     }
     
@@ -219,7 +219,7 @@ public class Alert: LKAlertController {
     - parameter message:  Body of the alert
     */
     public init(message: String?) {
-        super.init(style: .Alert)
+        super.init(style: .alert)
         self.message = message
         self.title = message == nil ? nil : ""
     }
@@ -231,7 +231,7 @@ public class Alert: LKAlertController {
     - parameter message:  Body of the alert
     */
     public init(title: String?, message: String?) {
-        super.init(style: .Alert)
+        super.init(style: .alert)
         self.title = title
         self.message = message
     }
@@ -241,8 +241,8 @@ public class Alert: LKAlertController {
     
     - parameter title:  Title of the button
     */
-    public func addAction(title: String) -> Alert {
-        return addAction(title, style: .Cancel, preferredAction: false, handler: nil)
+    public func addAction(_ title: String) -> Alert {
+        return addAction(title, style: .cancel, preferredAction: false, handler: nil)
     }
     
     /**
@@ -252,7 +252,7 @@ public class Alert: LKAlertController {
     - parameter style:  Style of the button (.Default, .Cancel, .Destructive)
     - parameter handler:  Closure to call when the button is pressed
     */
-    public override func addAction(title: String, style: UIAlertActionStyle, handler: actionHandler?) -> Alert {
+    public override func addAction(_ title: String, style: UIAlertActionStyle, handler: actionHandler?) -> Alert {
         return addAction(title, style: style, preferredAction: false, handler: handler)
     }
     
@@ -264,7 +264,7 @@ public class Alert: LKAlertController {
      - parameter handler:  Closure to call when the button is pressed
      - parameter preferredAction: The preferred action for the user to take from an alert.
      */
-    public override func addAction(title: String, style: UIAlertActionStyle, preferredAction: Bool, handler: actionHandler?) -> Alert {
+    public override func addAction(_ title: String, style: UIAlertActionStyle, preferredAction: Bool, handler: actionHandler?) -> Alert {
         return super.addAction(title, style: style, preferredAction: preferredAction, handler: handler) as! Alert
     }
     
@@ -273,36 +273,36 @@ public class Alert: LKAlertController {
     
     - parameter textField:  textField to add to the alert (must be a var, not let)
     */
-    public func addTextField(inout textField: UITextField) -> Alert {
-        alertController.addTextFieldWithConfigurationHandler { (tf: UITextField!) -> Void in
+    public func addTextField(_ textField: UITextField) -> Alert {
+        alertController.addTextField { (tf: UITextField!) -> Void in
             tf.text = textField.text
             tf.placeholder = textField.placeholder
             tf.font = textField.font
             tf.textColor = textField.textColor
-            tf.secureTextEntry = textField.secureTextEntry
+            tf.isSecureTextEntry = textField.isSecureTextEntry
             tf.keyboardType = textField.keyboardType
             tf.autocapitalizationType = textField.autocapitalizationType
             tf.autocorrectionType = textField.autocorrectionType
             
-            textField = tf
+            //textField = tf
         }
         
         return self
     }
 	
 	///Set the view controller to present the alert in. By default this is the top controller in the window.
-	public override func presentIn(source: UIViewController) -> Alert {
+	public override func presentIn(_ source: UIViewController) -> Alert {
 		return super.presentIn(source) as! Alert
 	}
 	
 	//Delay the presentation of the controller.
-	public override func delay(time: NSTimeInterval) -> Alert {
+	public override func delay(_ time: TimeInterval) -> Alert {
 		return super.delay(time) as! Alert
 	}
     
     ///Shortcut method for adding an Okay button and showing the alert
     public func showOkay() {
-        super.addAction("Okay", style: .Cancel, handler: nil, preferredAction: false)
+        super.addAction("Okay", style: .cancel, preferredAction: false, handler: nil)
         show()
     }
 }
@@ -312,7 +312,7 @@ public class Alert: LKAlertController {
 public class ActionSheet: LKAlertController {
     ///Create a new action sheet without a title or message
     public init() {
-        super.init(style: .ActionSheet)
+        super.init(style: .actionSheet)
     }
     
     /**
@@ -321,7 +321,7 @@ public class ActionSheet: LKAlertController {
     - parameter title:  Title of the action sheet
     */
     public init(title: String?) {
-        super.init(style: .ActionSheet)
+        super.init(style: .actionSheet)
         self.title = title
     }
     
@@ -331,7 +331,7 @@ public class ActionSheet: LKAlertController {
     - parameter message:  Body of the action sheet
     */
     public init(message: String?) {
-        super.init(style: .ActionSheet)
+        super.init(style: .actionSheet)
         self.message = message
         self.title = message == nil ? nil : ""
     }
@@ -343,7 +343,7 @@ public class ActionSheet: LKAlertController {
     - parameter message:  Body of the action sheet
     */
     public init(title: String?, message: String?) {
-        super.init(style: .ActionSheet)
+        super.init(style: .actionSheet)
         self.title = title
         self.message = message
     }
@@ -353,8 +353,8 @@ public class ActionSheet: LKAlertController {
     
     - parameter title:  Title of the button
     */
-    public func addAction(title: String) -> ActionSheet {
-        return addAction(title, style: .Cancel, handler: nil)
+    public func addAction(_ title: String) -> ActionSheet {
+        return addAction(title, style: .cancel, handler: nil)
     }
     
     /**
@@ -364,17 +364,17 @@ public class ActionSheet: LKAlertController {
     - parameter style:  Style of the button (.Default, .Cancel, .Destructive)
     - parameter handler:  Closure to call when the button is pressed
     */
-    public override func addAction(title: String, style: UIAlertActionStyle, handler: actionHandler?) -> ActionSheet {
+    public override func addAction(_ title: String, style: UIAlertActionStyle, handler: actionHandler?) -> ActionSheet {
         return super.addAction(title, style: style, preferredAction: false, handler: handler) as! ActionSheet
     }
 	
 	///Set the view controller to present the alert in. By default this is the top controller in the window.
-	public override func presentIn(source: UIViewController) -> ActionSheet {
+	public override func presentIn(_ source: UIViewController) -> ActionSheet {
 		return super.presentIn(source) as! ActionSheet
 	}
 	
 	//Delay the presentation of the controller.
-	public override func delay(time: NSTimeInterval) -> ActionSheet {
+	open override func delay(_ time: TimeInterval) -> ActionSheet {
 		return super.delay(time) as! ActionSheet
 	}
     
@@ -384,7 +384,7 @@ public class ActionSheet: LKAlertController {
     
     - parameter item:  UIBarButtonItem that the action sheet will present from
     */
-    public func setBarButtonItem(item: UIBarButtonItem) -> ActionSheet {
+    public func setBarButtonItem(_ item: UIBarButtonItem) -> ActionSheet {
         if let popoverController = alertController.popoverPresentationController {
             popoverController.barButtonItem = item
         }
@@ -399,7 +399,7 @@ public class ActionSheet: LKAlertController {
     
     - parameter source:  The view the action sheet will present from
     */
-    public func setPresentingSource(source: UIView) -> ActionSheet {
+    public func setPresentingSource(_ source: UIView) -> ActionSheet {
         if let popoverController = alertController.popoverPresentationController {
             popoverController.sourceView = source
             popoverController.sourceRect = source.bounds

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "7.1"
+    version: "8.0"
 test:
   override:
     - set -o pipefail &&


### PR DESCRIPTION
Significant change on line 287 in method:

```
public func addTextField(inout textField: UITextField) -> Alert {
```

to

```
public func addTextField(_ textField: UITextField) -> Alert {
```

Why was the textfield `inout`? From my understanding this only makes sense if you want to modify an Alert's value while it's being displayed?
